### PR TITLE
Improve Cypress article tests

### DIFF
--- a/cypress/e2e/1-getting-started/02_GlobalFeedLikesCount.spec.js
+++ b/cypress/e2e/1-getting-started/02_GlobalFeedLikesCount.spec.js
@@ -1,72 +1,65 @@
-describe('Test with Back-end API for checking global feed likes count', () => {
-    beforeEach('login to application', () => {
-        cy.intercept('GET', 'https://conduit-api.bondaracademy.com/api/articles', { fixture: 'articles.json' });
-        cy.loginToApplication();
+describe('Global feed like counts', () => {
+  beforeEach(() => {
+    cy.intercept(
+      'GET',
+      `${Cypress.env('apiUrl')}/api/articles/feed*`,
+      {
+        statusCode: 200,
+        body: {
+          articles: [],
+          articlesCount: 0,
+        },
+      },
+    ).as('getFeed');
+
+    cy.fixture('articles').then((articlesFixture) => {
+      cy.intercept(
+        'GET',
+        `${Cypress.env('apiUrl')}/api/articles?limit=10&offset=0`,
+        {
+          statusCode: 200,
+          body: articlesFixture,
+        },
+      ).as('getArticlesPage');
+
+      cy.intercept(
+        'GET',
+        `${Cypress.env('apiUrl')}/api/articles`,
+        {
+          statusCode: 200,
+          body: articlesFixture,
+        },
+      ).as('getArticles');
     });
 
-    it('verify global feed likes count', () => {
-        cy.intercept('GET', 'https://conduit-api.bondaracademy.com/api/articles/feed*', {
-            articles: [],
-            articlesCount: 0,
-        }).as('getFeed');
+    cy.loginToApplication();
+  });
 
-        cy.intercept('GET', 'https://conduit-api.bondaracademy.com/api/articles/*', (req) => {
-            req.reply({
-                article: {
-                    id: 12,
-                    slug: "Discover-Bondar-Academy:-Your-Gateway-to-Efficient-Learning-1",
-                    title: "Discover Bondar Academy: Your Gateway to Efficient Learning",
-                    description: "Discover Bondar Academy's unique place in the educational landscape...",
-                    body: "Bondar Academy is a leading platform for efficient education...",
-                    createdAt: "2024-01-27T21:52:32.682Z",
-                    updatedAt: "2024-01-27T21:52:32.682Z",
-                    authorId: 1,
-                    tagList: [
-                        "qa career",
-                        "Bondar Academy",
-                        "QA Skills",
-                        "Value-Focused"
-                    ],
-                    author: {
-                        username: "Artem Bondar",
-                        bio: null,
-                        image: "https://storage.googleapis.com/bondar-academy-visuals/Android.png",
-                        following: false
-                    },
-                    favoritedBy: [
-                        {
-                            id: 3,
-                            email: "cytest@test.com",
-                            username: "CyTest",
-                            password: "$2a$10$yKBkKY1DHqpUg3I0Ts0HKer0bDYu6vYZ7cZllkbzq9RjFFNnOdcUK",
-                            image: "https://api.realworld.io/images/smiley-cyrus.jpeg",
-                            bio: "Dapifer ambulo tabella celer maiores.",
-                            demo: false
-                        },
-                    ],
-                    favorited: true,
-                    favoritesCount: 348,
-                }
-            });
-        }).as('getArticle');
+  it('renders a consistent like count for each article', () => {
+    cy.contains('Global Feed').click();
+    cy.wait(['@getFeed', '@getArticlesPage']);
 
-        // Visit the global feed
-        cy.contains('Global Feed').click();
+    cy.fixture('articles').then(({ articles }) => {
+      cy.get('app-article-list app-article-preview').should(
+        'have.length',
+        articles.length,
+      );
 
-        // Check the initial heart counts dynamically
-        cy.get('app-article-list button').each(($button, index) => {
-            cy.wrap($button).invoke('text').then((text) => {
-                const heartCount = parseInt(text.trim(), 10);
-                expect(heartCount).to.be.a('number').and.greaterThan(0);
-                cy.log(`Article ${index + 1} has ${heartCount} likes`);
-            });
-        });
+      cy.get('app-article-list app-article-preview').each(($preview, index) => {
+        cy.wrap($preview)
+          .find('button.btn-outline-primary')
+          .invoke('text')
+          .then((text) => {
+            const heartCount = parseInt(text.trim(), 10);
+            expect(heartCount).to.eq(articles[index].favoritesCount);
+          });
+      });
 
-        // Load articles fixture and validate data consistency
-        cy.fixture('articles').then((file) => {
-            expect(file.articles).to.have.length.greaterThan(1); // Ensure there are at least two articles
-            const articleLink = file.articles[1].slug; // Get the slug of the second article
-            cy.log(`Slug of the second article: ${articleLink}`);
-        });
+      const { slug, title } = articles[1];
+      cy.contains('app-article-preview', title)
+        .find('a.preview-link')
+        .should('have.attr', 'href')
+        .and('include', slug);
     });
+  });
 });

--- a/cypress/e2e/1-getting-started/03_DeletePostArticle.spec.js
+++ b/cypress/e2e/1-getting-started/03_DeletePostArticle.spec.js
@@ -1,45 +1,99 @@
-describe('Test with Back-end API', () => {
+const articleForDeletion = {
+  title: 'This is the title articles for deleting',
+  description: 'This is a description',
+  body: 'This is a body of the article',
+  slug: 'this-is-the-title-articles-for-deleting',
+  tagList: ['testing'],
+};
 
-    beforeEach('login to application', () => {
-      cy.intercept('GET', 'https://conduit-api.bondaracademy.com/api/articles', { fixture: 'tags.json' })
-      cy.loginToApplication()
-    })
-  
-    it('Verify creating and deleting an article', () => {
-      cy.intercept('POST', '**/articles*').as('postArticles')
-      cy.intercept('DELETE', '**/articles/*').as('deleteArticle')
-      cy.intercept('GET', '**/articles?limit=10&offset=0').as('getArticles')
-  
-      // Create a new article
-      cy.contains('New Article').click()
-  
-      cy.get('[formcontrolname="title"]').type('This is the title articles for deleting')
-      cy.get('[formcontrolname="description"]').type('This is a description')
-      cy.get('[formcontrolname="body"]').type('This is a body of the article')
-      cy.contains('Publish Article').click()
-  
-      // Verify the article is created successfully
-      cy.wait('@postArticles', { timeout: 10000 }).then((xhr) => {
-        expect(xhr.response.statusCode).to.equal(201)
-        expect(xhr.request.body.article.body).to.equal('This is a body of the article')
-        expect(xhr.response.body.article.description).to.equal('This is a description')
-      })
-  
-      // Delete the created article
-      cy.contains('Delete Article').click()
-  
-      // Verify the delete request
-      cy.wait('@deleteArticle', { timeout: 10000 }).then((xhr) => {
-        expect(xhr.response.statusCode).to.equal(204)
-      })
-  
-      // Verify the article is no longer in the list
-      cy.wait('@getArticles').then((xhr) => {
-        expect(xhr.response.statusCode).to.equal(200)
-        const articles = xhr.response.body.articles
-        const deletedArticle = articles.find(article => article.title === 'This is the title articles for deleting')
-        expect(deletedArticle).to.be.undefined
-      })
-    })
-  })
-  
+describe('Article deletion', () => {
+  beforeEach(() => {
+    cy.intercept('GET', `${Cypress.env('apiUrl')}/api/tags`, {
+      fixture: 'tags.json',
+    }).as('getTags');
+
+    cy.loginToApplication();
+    cy.wait('@getTags');
+  });
+
+  it('creates and deletes an article using the API', () => {
+    const timestamps = {
+      createdAt: '2024-01-27T21:52:32.682Z',
+      updatedAt: '2024-01-27T21:52:32.682Z',
+    };
+
+    const articleResponse = {
+      article: {
+        ...articleForDeletion,
+        ...timestamps,
+        author: {
+          username: 'CyTester',
+          bio: null,
+          image: 'https://api.realworld.io/images/smiley-cyrus.jpeg',
+          following: false,
+        },
+        favorited: false,
+        favoritesCount: 0,
+      },
+    };
+
+    cy.intercept('POST', `${Cypress.env('apiUrl')}/api/articles`, (req) => {
+      expect(req.body.article).to.deep.include({
+        title: articleForDeletion.title,
+        description: articleForDeletion.description,
+        body: articleForDeletion.body,
+      });
+
+      req.reply({
+        statusCode: 201,
+        body: articleResponse,
+      });
+    }).as('postArticle');
+
+    cy.intercept(
+      'GET',
+      `${Cypress.env('apiUrl')}/api/articles/${articleForDeletion.slug}`,
+      {
+        statusCode: 200,
+        body: articleResponse,
+      },
+    ).as('getCreatedArticle');
+
+    cy.intercept(
+      'DELETE',
+      `${Cypress.env('apiUrl')}/api/articles/${articleForDeletion.slug}`,
+      {
+        statusCode: 204,
+      },
+    ).as('deleteArticle');
+
+    cy.intercept(
+      'GET',
+      `${Cypress.env('apiUrl')}/api/articles?limit=10&offset=0`,
+      {
+        statusCode: 200,
+        body: {
+          articles: [],
+          articlesCount: 0,
+        },
+      },
+    ).as('articlesAfterDelete');
+
+    cy.contains('New Article').click();
+
+    cy.get('[formcontrolname="title"]').type(articleForDeletion.title);
+    cy.get('[formcontrolname="description"]').type(articleForDeletion.description);
+    cy.get('[formcontrolname="body"]').type(articleForDeletion.body);
+    cy.contains('Publish Article').click();
+
+    cy.wait('@postArticle').its('response.statusCode').should('eq', 201);
+    cy.wait('@getCreatedArticle');
+
+    cy.contains('Delete Article').click();
+
+    cy.wait('@deleteArticle').its('response.statusCode').should('eq', 204);
+    cy.wait('@articlesAfterDelete');
+
+    cy.get('app-article-list').should('not.contain', articleForDeletion.title);
+  });
+});

--- a/cypress/e2e/1-getting-started/04_LogOut.spec.js
+++ b/cypress/e2e/1-getting-started/04_LogOut.spec.js
@@ -1,17 +1,13 @@
 /// <reference types="cypress" />
 
+describe('User logout', () => {
+  beforeEach(() => {
+    cy.loginToApplication();
+  });
 
-describe('Test log out', () => {
-
-    beforeEach('login to the app', () => {
-        cy.loginToApplication()
-    })
-
-
-    it('verify use can log out successfully', {retries: 2}, () => {
-        cy.contains('Settings').click()
-        cy.contains('Or click here to logout').click()
-        cy.get('.navbar-nav').should('contain', 'Sign up')
-    })
-
-})
+  it('allows the user to log out successfully', { retries: 2 }, () => {
+    cy.contains('Settings').click();
+    cy.contains('Or click here to logout').click();
+    cy.get('.navbar-nav').should('contain', 'Sign up');
+  });
+});

--- a/cypress/fixtures/tags.json
+++ b/cypress/fixtures/tags.json
@@ -1,7 +1,8 @@
 {
-    "tags": [
-        "cypress",
-        "automation",
-        "testing"
-    ]
+  "tags": [
+    "Testing",
+    "GitHub",
+    "Coding",
+    "Git"
+  ]
 }


### PR DESCRIPTION
## Summary
- stub the Conduit API in the article creation spec to validate request and UI rendering
- make the global feed and delete specs deterministic with fixture-backed intercepts
- refresh the logout test and tags fixture to align with updated expectations

## Testing
- npx cypress run --spec "cypress/e2e/1-getting-started/*.spec.js" *(fails: npm error code E403 403 Forbidden - GET https://registry.npmjs.org/cypress)*

------
https://chatgpt.com/codex/tasks/task_e_68e62e2e14a083218511fd1f2399d78b