### PR TITLE
Update artifact upload action to v4

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -39,7 +39,7 @@ jobs:
       # Step 5: Upload test results
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Cypress-Test-Reports
           path: cypress/reports/*.json


### PR DESCRIPTION
## Summary
- update the API test workflow to use `actions/upload-artifact@v4` so it no longer relies on the deprecated v3 release

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e6397a2aa08321b5733aaedb81fc65