### PR TITLE
Fix Cypress reporter configuration

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,10 +5,12 @@ module.exports = defineConfig({
   viewportWidth: 1920,
   video: false,
 
-  // Настройка репортера
-  reporter: "cypress-multi-reporters",
+  reporter: "mochawesome",
   reporterOptions: {
-    configFile: "reporter-config.json",
+    reportDir: "cypress/results",
+    overwrite: false,
+    html: false,
+    json: true,
   },
 
   e2e: {
@@ -40,14 +42,5 @@ module.exports = defineConfig({
     baseUrl: "https://conduit.bondaracademy.com/",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
     excludeSpecPattern: "**/examples/*",
-
-    // Добавление mochawesome как дополнительного репортера
-    reporter: "mochawesome",
-    reporterOptions: {
-      reportDir: "cypress/results",
-      overwrite: false,
-      html: false,
-      json: true,
-    },
   },
 });


### PR DESCRIPTION
## Summary
- configure Cypress to use the mochawesome reporter at the project root
- remove the duplicate reporter definition inside the `e2e` block that caused `[object Object]` runtime errors

## Testing
- npx cypress run *(fails: Cypress binary download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e63ca3531083218348a18a609b2342