### PR TITLE
Fix Cypress reporter sanitization to avoid pipeline failures

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,17 +1,33 @@
 const { defineConfig } = require("cypress");
 
+const DEFAULT_REPORTER = "mochawesome";
+const DEFAULT_REPORTER_OPTIONS = {
+  reportDir: "cypress/results",
+  overwrite: false,
+  html: false,
+  json: true,
+};
+
+const sanitizeReporter = (value) => {
+  if (typeof value !== "string") {
+    return { value: DEFAULT_REPORTER, wasInvalid: true };
+  }
+
+  const trimmedValue = value.trim();
+  if (!trimmedValue || trimmedValue === "[object Object]") {
+    return { value: DEFAULT_REPORTER, wasInvalid: true };
+  }
+
+  return { value: trimmedValue, wasInvalid: false };
+};
+
 module.exports = defineConfig({
   viewportHeight: 1080,
   viewportWidth: 1920,
   video: false,
 
-  reporter: "mochawesome",
-  reporterOptions: {
-    reportDir: "cypress/results",
-    overwrite: false,
-    html: false,
-    json: true,
-  },
+  reporter: DEFAULT_REPORTER,
+  reporterOptions: { ...DEFAULT_REPORTER_OPTIONS },
 
   e2e: {
     setupNodeEvents(on, config) {
@@ -19,12 +35,25 @@ module.exports = defineConfig({
       const username = process.env.DB_USERNAME || "dorothyperkins420@gmail.com";
       const password = process.env.PASSWORD || "Doroti36_";
 
+      const { value: sanitizedReporter, wasInvalid } = sanitizeReporter(config.reporter);
+      const reporterChanged = sanitizedReporter !== config.reporter;
+      config.reporter = sanitizedReporter;
+
+      const hasValidReporterOptions =
+        config.reporterOptions && typeof config.reporterOptions === "object";
+      const shouldResetReporterOptions =
+        !hasValidReporterOptions || wasInvalid;
+
+      if (shouldResetReporterOptions) {
+        config.reporterOptions = { ...DEFAULT_REPORTER_OPTIONS };
+      }
+
       // Обработка ошибок, если переменные окружения отсутствуют
       if (!password) {
         throw new Error("missing PASSWORD environment variable");
       }
 
-      config.env = { username, password };
+      config.env = { ...config.env, username, password };
       return config;
     },
 


### PR DESCRIPTION
## Summary
- sanitize the Cypress reporter configuration before runs and default to mochawesome when invalid data is supplied
- reset reporter options only when the provided configuration is unusable and keep other environment values intact

## Testing
- not run (Cypress binary is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e63f39ec048321ab3ac8e28de21640