### PR TITLE
Fix Cypress reporter configuration

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -31,10 +31,18 @@ jobs:
 
       # Step 4: Run API tests sequentially and generate reports
       - name: Run API Tests Sequentially
+        env:
+          CYPRESS_MULTI_REPORTER_OPTIONS: >-
+            reporterEnabled=spec,mocha-junit-reporter,mochawesome;
+            mochawesomeReporterOptions.reportDir=cypress/results/mochawesome;
+            mochawesomeReporterOptions.overwrite=false;
+            mochawesomeReporterOptions.html=false;
+            mochawesomeReporterOptions.json=true;
+            mochaJunitReporterReporterOptions.mochaFile=cypress/results/junit/results-[hash].xml
         run: |
-          npx cypress run --reporter mochawesome --spec cypress/e2e/1-getting-started/01_LoginandCreateNewPost.spec.js
-          npx cypress run --reporter mochawesome --spec cypress/e2e/1-getting-started/02_GlobalFeedLikesCount.spec.js
-          npx cypress run --reporter mochawesome --spec cypress/e2e/1-getting-started/03_DeletePostArticle.spec.js
+          npx cypress run --reporter cypress-multi-reporters --reporter-options "$CYPRESS_MULTI_REPORTER_OPTIONS" --spec cypress/e2e/1-getting-started/01_LoginandCreateNewPost.spec.js
+          npx cypress run --reporter cypress-multi-reporters --reporter-options "$CYPRESS_MULTI_REPORTER_OPTIONS" --spec cypress/e2e/1-getting-started/02_GlobalFeedLikesCount.spec.js
+          npx cypress run --reporter cypress-multi-reporters --reporter-options "$CYPRESS_MULTI_REPORTER_OPTIONS" --spec cypress/e2e/1-getting-started/03_DeletePostArticle.spec.js
 
       # Step 5: Upload test results
       - name: Upload test results
@@ -42,4 +50,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Cypress-Test-Reports
-          path: cypress/reports/*.json
+          path: cypress/results/mochawesome/*.json

--- a/cypress/reporter-config.json
+++ b/cypress/reporter-config.json
@@ -1,12 +1,12 @@
 {
-  "reporterEnabled": "mocha-junit-reporter, mochawesome",
+  "reporterEnabled": "spec, mocha-junit-reporter, mochawesome",
   "mochaJunitReporterReporterOptions": {
     "mochaFile": "cypress/results/junit/results-[hash].xml"
   },
-  "reporterOptions": {
-      "reportDir": "cypress/results",
-      "overwrite": false,
-      "html": false,
-      "json": true
-    }
+  "mochawesomeReporterOptions": {
+    "reportDir": "cypress/results/mochawesome",
+    "overwrite": false,
+    "html": false,
+    "json": true
+  }
 }


### PR DESCRIPTION
## Summary
- configure Cypress to use the cypress-multi-reporters reporter with validated overrides
- align the standalone reporter configuration file with the new defaults
- update the GitHub Actions workflow to pass reporter options as strings and collect artifacts from the new directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6426114c08321a2b1cddb70514eb8