### PR TITLE
Refactor Cypress article helpers

### DIFF
--- a/cypress/e2e/1-getting-started/01_LoginandCreateNewPost.spec.js
+++ b/cypress/e2e/1-getting-started/01_LoginandCreateNewPost.spec.js
@@ -1,3 +1,9 @@
+import {
+  buildArticleResponse,
+  createTimestamps,
+  defaultAuthor,
+} from '../../support/utils/article.js';
+
 const article = {
   title: 'This is the title',
   description: 'This is a description',
@@ -6,28 +12,19 @@ const article = {
   tagList: ['testing'],
 };
 
-const author = {
-  username: 'CyTester',
-  bio: null,
-  image: 'https://api.realworld.io/images/smiley-cyrus.jpeg',
-  following: false,
-};
-
 describe('Article creation flow', () => {
   beforeEach(() => {
-    cy.intercept('GET', `${Cypress.env('apiUrl')}/api/tags`, {
-      fixture: 'tags.json',
-    }).as('getTags');
-
+    cy.stubPopularTags();
     cy.loginToApplication();
     cy.wait('@getTags');
   });
 
   it('creates a new article and validates the API contract', () => {
-    const timestamps = {
-      createdAt: '2024-01-27T21:52:32.682Z',
-      updatedAt: '2024-01-27T21:52:32.682Z',
-    };
+    const timestamps = createTimestamps();
+    const articleResponse = buildArticleResponse(article, {
+      author: defaultAuthor,
+      timestamps,
+    });
 
     cy.intercept('POST', `${Cypress.env('apiUrl')}/api/articles`, (req) => {
       expect(req.body.article).to.deep.include({
@@ -38,15 +35,7 @@ describe('Article creation flow', () => {
 
       req.reply({
         statusCode: 201,
-        body: {
-          article: {
-            ...article,
-            ...timestamps,
-            author,
-            favorited: false,
-            favoritesCount: 0,
-          },
-        },
+        body: articleResponse,
       });
     }).as('postArticle');
 
@@ -55,15 +44,7 @@ describe('Article creation flow', () => {
       `${Cypress.env('apiUrl')}/api/articles/${article.slug}`,
       {
         statusCode: 200,
-        body: {
-          article: {
-            ...article,
-            ...timestamps,
-            author,
-            favorited: false,
-            favoritesCount: 0,
-          },
-        },
+        body: articleResponse,
       },
     ).as('getCreatedArticle');
 
@@ -75,7 +56,9 @@ describe('Article creation flow', () => {
     cy.contains('Publish Article').click();
 
     cy.wait('@postArticle').its('response.statusCode').should('eq', 201);
-    cy.wait('@getCreatedArticle');
+    cy.wait('@getCreatedArticle')
+      .its('response.body.article')
+      .should('deep.include', article);
 
     cy.get('h1').should('contain', article.title);
     cy.get('.article-content').should('contain', article.body);

--- a/cypress/e2e/1-getting-started/02_GlobalFeedLikesCount.spec.js
+++ b/cypress/e2e/1-getting-started/02_GlobalFeedLikesCount.spec.js
@@ -1,5 +1,7 @@
 describe('Global feed like counts', () => {
   beforeEach(() => {
+    cy.fixture('articles').as('articlesResponse');
+
     cy.intercept(
       'GET',
       `${Cypress.env('apiUrl')}/api/articles/feed*`,
@@ -12,7 +14,7 @@ describe('Global feed like counts', () => {
       },
     ).as('getFeed');
 
-    cy.fixture('articles').then((articlesFixture) => {
+    cy.get('@articlesResponse').then((articlesFixture) => {
       cy.intercept(
         'GET',
         `${Cypress.env('apiUrl')}/api/articles?limit=10&offset=0`,
@@ -21,15 +23,6 @@ describe('Global feed like counts', () => {
           body: articlesFixture,
         },
       ).as('getArticlesPage');
-
-      cy.intercept(
-        'GET',
-        `${Cypress.env('apiUrl')}/api/articles`,
-        {
-          statusCode: 200,
-          body: articlesFixture,
-        },
-      ).as('getArticles');
     });
 
     cy.loginToApplication();
@@ -39,7 +32,7 @@ describe('Global feed like counts', () => {
     cy.contains('Global Feed').click();
     cy.wait(['@getFeed', '@getArticlesPage']);
 
-    cy.fixture('articles').then(({ articles }) => {
+    cy.get('@articlesResponse').then(({ articles }) => {
       cy.get('app-article-list app-article-preview').should(
         'have.length',
         articles.length,
@@ -60,6 +53,10 @@ describe('Global feed like counts', () => {
         .find('a.preview-link')
         .should('have.attr', 'href')
         .and('include', slug);
+
+      cy.contains('app-article-preview', articles[0].title)
+        .find('a.author')
+        .should('contain', articles[0].author.username);
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,55 +1,28 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-// Cypress.Commands.add('loginToApplication', () => {
-//     cy.visit('/login')
-//     cy.get('[placeholder="Email"]').type('dorothyperkins420@gmail.com')
-//     cy.get('[placeholder="Password"]').type('Doroti36_')
-//     cy.get('form').submit()
-// })
-
+const apiUrl = Cypress.env('apiUrl');
 
 Cypress.Commands.add('loginToApplication', () => {
-    
-    const userCredentials = {
-        "user": {
-            "email": Cypress.env("username"),
-            "password": Cypress.env("password")
-        }
-    }
+  const userCredentials = {
+    user: {
+      email: Cypress.env('username'),
+      password: Cypress.env('password'),
+    },
+  };
 
-    cy.request('POST', Cypress.env('apiUrl')+'/api/users/login', userCredentials)
-        .its('body').then( body => {
-            const token = body.user.token
-            cy.wrap(token).as('token')
-            cy.visit('/', {
-                onBeforeLoad (win){
-                    win.localStorage.setItem('jwtToken', token)
-                }
-            })
+  cy.request('POST', `${apiUrl}/api/users/login`, userCredentials)
+    .its('body.user.token')
+    .then((token) => {
+      cy.wrap(token).as('token');
 
-        })
-    
-})
+      cy.visit('/', {
+        onBeforeLoad(win) {
+          win.localStorage.setItem('jwtToken', token);
+        },
+      });
+    });
+});
+
+Cypress.Commands.add('stubPopularTags', () => {
+  cy.intercept('GET', `${apiUrl}/api/tags`, {
+    fixture: 'tags.json',
+  }).as('getTags');
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands.js';
 
 // Alternatively you can use CommonJS syntax:
-// require('./commands')
+// require('./commands');

--- a/cypress/support/utils/article.js
+++ b/cypress/support/utils/article.js
@@ -1,0 +1,36 @@
+const defaultAuthorDetails = {
+  username: 'CyTester',
+  bio: null,
+  image: 'https://api.realworld.io/images/smiley-cyrus.jpeg',
+  following: false,
+};
+
+export const defaultAuthor = Object.freeze({ ...defaultAuthorDetails });
+
+export const createTimestamps = () => {
+  const timestamp = new Date().toISOString();
+
+  return {
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+};
+
+export const buildArticleResponse = (article, options = {}) => {
+  const {
+    author = defaultAuthor,
+    timestamps = createTimestamps(),
+    overrides = {},
+  } = options;
+
+  return {
+    article: {
+      ...article,
+      ...timestamps,
+      author,
+      favorited: false,
+      favoritesCount: 0,
+      ...overrides,
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- add reusable article response helpers for Cypress tests
- extend Cypress commands with tag stubbing and cleaner login flow
- update article flow specs to use shared helpers and stronger assertions

## Testing
- `npx cypress run --spec "cypress/e2e/1-getting-started/*.spec.js"` *(fails: Cypress binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e64a89c9f48321a7d93dc9a93d8ead