### PR TITLE
Fix Cypress reporter options parsing

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -33,12 +33,7 @@ jobs:
       - name: Run API Tests Sequentially
         env:
           CYPRESS_MULTI_REPORTER_OPTIONS: >-
-            reporterEnabled=spec,mocha-junit-reporter,mochawesome;
-            mochawesomeReporterOptions.reportDir=cypress/results/mochawesome;
-            mochawesomeReporterOptions.overwrite=false;
-            mochawesomeReporterOptions.html=false;
-            mochawesomeReporterOptions.json=true;
-            mochaJunitReporterReporterOptions.mochaFile=cypress/results/junit/results-[hash].xml
+            {"reporterEnabled":"spec,mocha-junit-reporter,mochawesome","mochawesomeReporterOptions":{"reportDir":"cypress/results/mochawesome","overwrite":false,"html":false,"json":true},"mochaJunitReporterReporterOptions":{"mochaFile":"cypress/results/junit/results-[hash].xml"}}
         run: |
           npx cypress run --reporter cypress-multi-reporters --reporter-options "$CYPRESS_MULTI_REPORTER_OPTIONS" --spec cypress/e2e/1-getting-started/01_LoginandCreateNewPost.spec.js
           npx cypress run --reporter cypress-multi-reporters --reporter-options "$CYPRESS_MULTI_REPORTER_OPTIONS" --spec cypress/e2e/1-getting-started/02_GlobalFeedLikesCount.spec.js

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -29,20 +29,34 @@ const sanitizeReporter = (value) => {
 };
 
 const resolveReporterOptions = (value) => {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    const merged = { ...DEFAULT_REPORTER_OPTIONS, ...value };
+  let resolvedValue = value;
 
-    if (value.mochawesomeReporterOptions) {
+  if (typeof resolvedValue === "string") {
+    try {
+      resolvedValue = JSON.parse(resolvedValue);
+    } catch (error) {
+      console.warn(
+        "Unable to parse reporter options string. Falling back to default reporter options.",
+        error
+      );
+      resolvedValue = undefined;
+    }
+  }
+
+  if (resolvedValue && typeof resolvedValue === "object" && !Array.isArray(resolvedValue)) {
+    const merged = { ...DEFAULT_REPORTER_OPTIONS, ...resolvedValue };
+
+    if (resolvedValue.mochawesomeReporterOptions) {
       merged.mochawesomeReporterOptions = {
         ...DEFAULT_REPORTER_OPTIONS.mochawesomeReporterOptions,
-        ...value.mochawesomeReporterOptions,
+        ...resolvedValue.mochawesomeReporterOptions,
       };
     }
 
-    if (value.mochaJunitReporterReporterOptions) {
+    if (resolvedValue.mochaJunitReporterReporterOptions) {
       merged.mochaJunitReporterReporterOptions = {
         ...DEFAULT_REPORTER_OPTIONS.mochaJunitReporterReporterOptions,
-        ...value.mochaJunitReporterReporterOptions,
+        ...resolvedValue.mochaJunitReporterReporterOptions,
       };
     }
 


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to pass Cypress reporter options as JSON for compatibility with newer CLI parsing
- make the Cypress configuration resilient to string-based reporter options by attempting JSON parsing before falling back to defaults

## Testing
- `npx cypress run --reporter cypress-multi-reporters --reporter-options '{"reporterEnabled":"spec,mocha-junit-reporter,mochawesome","mochawesomeReporterOptions":{"reportDir":"cypress/results/mochawesome","overwrite":false,"html":false,"json":true},"mochaJunitReporterReporterOptions":{"mochaFile":"cypress/results/junit/results-[hash].xml"}}' --spec cypress/e2e/1-getting-started/01_LoginandCreateNewPost.spec.js --config video=false` *(fails: Cypress binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e64ef187f883218f813c05001188e7